### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "nodemailer": "^6.9.7",
     "nodemon": "^3.0.1",
     "path": "^0.12.7",
-    "randomstring": "^1.3.0"
+    "randomstring": "^1.3.0",
+    "express-rate-limit": "^8.1.0"
   }
 }

--- a/routes/story.js
+++ b/routes/story.js
@@ -1,13 +1,24 @@
 import express from "express";
 import { protectRoute } from "../middleware/auth.js";
 import { addStory, deleteStory, editStory, getAllStories, getStoryById } from "../controllers/story.js";
+// Import rate limiter middleware
+import rateLimit from "express-rate-limit";
 
 const router = express.Router();
+
+// Rate limiter: allow max 5 deletes per minute per IP
+const deleteLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5,
+  message: "Too many delete requests from this IP, please try again later.",
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
 
 router.post("/addstory", protectRoute, addStory);
 router.get("/getAllStories", getAllStories);
 router.get("/:id", protectRoute, getStoryById);
 router.put("/:id", protectRoute, editStory);
-router.delete("/:id",protectRoute, deleteStory);
+router.delete("/:id", protectRoute, deleteLimiter, deleteStory);
 
 export const storyRouter = router;


### PR DESCRIPTION
Potential fix for [https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/17](https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/17)

To fix the missing rate limiting, the best approach is to add rate-limiting middleware to the `DELETE /:id` route in `routes/story.js`. Since the code uses ECMAScript modules (with `import`), we need to find and import a compatible rate-limiter, such as `express-rate-limit`. We will import and configure a rate limiter (e.g., allowing a modest number of deletes per minute per IP, such as 5 per minute), and apply it specifically to the DELETE route to avoid interfering with other story routes.

The fix will require:
- Adding an import for `express-rate-limit`.
- Initializing the rate limiter.
- Applying the rate-limiter middleware to the DELETE route handler, in addition to the existing `protectRoute` middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
