### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/controllers/story.js
+++ b/controllers/story.js
@@ -92,13 +92,39 @@ export const editStory = async (req, res) => {
     // Get the updated story data from the request body
     const { title, summary, content, image } = req.body;
 
-    // Find the story by ID and update its properties
-    const updatedStory = await Story.findByIdAndUpdate(storyId, {
-      title,
-      summary,
-      content,
-      image,
-    });
+    // Validate input types to prevent NoSQL injection
+    const fieldsToUpdate = {};
+    if (title !== undefined) {
+      if (typeof title !== "string") {
+        return res.status(400).json({ error: "Invalid type for title" });
+      }
+      fieldsToUpdate.title = title;
+    }
+    if (summary !== undefined) {
+      if (typeof summary !== "string") {
+        return res.status(400).json({ error: "Invalid type for summary" });
+      }
+      fieldsToUpdate.summary = summary;
+    }
+    if (content !== undefined) {
+      if (typeof content !== "string") {
+        return res.status(400).json({ error: "Invalid type for content" });
+      }
+      fieldsToUpdate.content = content;
+    }
+    if (image !== undefined) {
+      if (typeof image !== "string") {
+        return res.status(400).json({ error: "Invalid type for image" });
+      }
+      fieldsToUpdate.image = image;
+    }
+
+    // Find the story by ID and update its properties, using $set to prevent operator injection
+    const updatedStory = await Story.findByIdAndUpdate(
+      storyId,
+      { $set: fieldsToUpdate },
+      { new: true }
+    );
 
     if (!updatedStory) {
       return res.status(404).json({


### PR DESCRIPTION
Potential fix for [https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/1](https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/1)

To fix this issue, we must ensure that all fields passed from `req.body` into the update object are pure literals (e.g., strings, not objects containing `$set`, etc.). Two main approaches are recommended:

1. **Strict type checking for each field:**  
   Check that each of `title`, `summary`, `content`, and `image` is either absent or a primitive type (string, null, etc.). If any is an object (or array), reject the request with 400 Bad Request.

2. **Construct the update object with `$set`:**  
   Explicitly use the `$set` operator for the update, ensuring arbitrary update operators from the user cannot be injected.

3. **[Preferred] Validate input types and then use `$set`:**  
   In `editStory`, validate each field's type before adding it to the update payload; build the update object manually with only the allowed fields, using `$set` as the update operator.

No new imports are needed. The changes are restricted to the `editStory` handler in controllers/story.js (lines 87-119).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
