### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/routes/story.js
+++ b/routes/story.js
@@ -15,10 +15,19 @@ const deleteLimiter = rateLimit({
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
 });
 
+// Rate limiter: allow max 10 edits per minute per IP
+const editLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10,
+  message: "Too many edit requests from this IP, please try again later.",
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.post("/addstory", protectRoute, addStory);
 router.get("/getAllStories", getAllStories);
 router.get("/:id", protectRoute, getStoryById);
-router.put("/:id", protectRoute, editStory);
+router.put("/:id", protectRoute, editLimiter, editStory);
 router.delete("/:id", protectRoute, deleteLimiter, deleteStory);
 
 export const storyRouter = router;


### PR DESCRIPTION
Potential fix for [https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/20](https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/20)

To fix the problem, we should add a rate limiting middleware for the `editStory` (PUT) endpoint. This is best accomplished by defining a rate limiter (similar to `deleteLimiter`), configured appropriately—for example, allowing a small, reasonable number of updates per minute per IP—and attaching it to the relevant route in the same middleware stack as `protectRoute`. 

Concretely:  
- Define a new rate limiter (e.g., `editLimiter`) with a safe default, for instance, 10 edits per minute per IP.
- Apply this rate limiter to the `PUT /:id` route as middleware, in the same way that `deleteLimiter` is applied to the `DELETE /:id` route.
- No changes are needed to imports as `express-rate-limit` is already imported.

All changes are confined to `routes/story.js`, no updates are needed elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
