### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/routes/story.js
+++ b/routes/story.js
@@ -24,9 +24,18 @@ const editLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+// Rate limiter: allow max 100 reads per 15 minutes per IP
+const readLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  message: "Too many requests for stories from this IP, please try again later.",
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.post("/addstory", protectRoute, addStory);
 router.get("/getAllStories", getAllStories);
-router.get("/:id", protectRoute, getStoryById);
+router.get("/:id", protectRoute, readLimiter, getStoryById);
 router.put("/:id", protectRoute, editLimiter, editStory);
 router.delete("/:id", protectRoute, deleteLimiter, deleteStory);
 


### PR DESCRIPTION
Potential fix for [https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/24](https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/24)

To fix the issue, we should add a rate-limiting middleware to the `getStoryById` route on line 29 in `routes/story.js`. A reasonable configuration is to set a limit on the number of allowed requests per IP within a given time window, e.g., 100 requests per 15 minutes, similar to the official Express-Rate-Limit recommendation for read endpoints. This fix involves:
- Creating a new rate limiter instance for the GET (read) operation.
- Adding that rate limiter as middleware to the `/:id` route.
Edits are fully contained within the lines shown above (no external file modification needed). No changes to controller logic are necessary. Importing `express-rate-limit` is already done in the shown code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
