### PR TITLE
Potential fix for code scanning alert no. 26: Missing rate limiting

### DIFF
--- a/routes/story.js
+++ b/routes/story.js
@@ -34,7 +34,7 @@ const readLimiter = rateLimit({
 });
 
 router.post("/addstory", protectRoute, addStory);
-router.get("/getAllStories", getAllStories);
+router.get("/getAllStories", readLimiter, getAllStories);
 router.get("/:id", protectRoute, readLimiter, getStoryById);
 router.put("/:id", protectRoute, editLimiter, editStory);
 router.delete("/:id", protectRoute, deleteLimiter, deleteStory);


### PR DESCRIPTION
Potential fix for [https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/26](https://github.com/edersonrnunes/simplebloggerapp-backend/security/code-scanning/26)

To fix the problem, we should add a rate-limiting middleware to the `/getAllStories` route to protect the endpoint against abuse such as denial-of-service attacks. The project already uses `express-rate-limit` for other routes, and a `readLimiter` with a reasonable configuration has been defined (lines 27–34) and is already used on the GET `/:id` route. The same `readLimiter` should also be applied to the `/getAllStories` route handler (line 37). The change is simple: add `readLimiter` as a middleware argument for the route definition on line 37.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
